### PR TITLE
Correctly pass static data to the resolver

### DIFF
--- a/src/data-sources/games.ts
+++ b/src/data-sources/games.ts
@@ -1,0 +1,19 @@
+import { Game } from '../generated/graphql'
+
+export const games: readonly Game[] = [
+  {
+    id: 'fate_grand_order',
+    name: 'Fate Grand/Order',
+    url: 'https://www.fate-go.jp/',
+  },
+  {
+    id: 'idolmaster_cinderella_girls',
+    name: 'アイドルマスターシンデレラガールズ',
+    url: 'https://cinderella.idolmaster.jp/',
+  },
+  {
+    id: 'umamusume_pretty_derby',
+    name: 'ウマ娘 プリティーダービー',
+    url: 'https://umamusume.jp/',
+  },
+]

--- a/src/data-sources/index.ts
+++ b/src/data-sources/index.ts
@@ -1,0 +1,10 @@
+import { Game } from '../generated/graphql'
+import { games } from './games'
+
+export type StaticDataSources = {
+  readonly games: readonly Game[],
+}
+
+export const staticDataSources: StaticDataSources = {
+  games: games,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { ApolloServer } from 'apollo-server'
 
-import { resolvers } from './resolvers'
+import { resolverContext, resolvers } from './resolvers'
 import { typeDefsList } from './schemas'
 
 const server = new ApolloServer({
   typeDefs: typeDefsList,
+  context: resolverContext,
   resolvers,
 })
 

--- a/src/resolvers/index.test.ts
+++ b/src/resolvers/index.test.ts
@@ -1,12 +1,13 @@
 import { ApolloServer } from 'apollo-server'
 
 import { typeDefsList } from '../schemas'
-import { resolvers } from './index'
+import { resolverContext, resolvers } from './index'
 
 const createTestServer = () => {
   return new ApolloServer({
     typeDefs: typeDefsList,
-    resolvers
+    context: resolverContext,
+    resolvers,
   });
 }
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,25 +1,18 @@
-import { Game, Resolvers } from '../generated/graphql'
+import { StaticDataSources, staticDataSources } from '../data-sources'
+import { Resolvers } from '../generated/graphql'
 
-const games: Game[] = [
-  {
-    id: 'fate_grand_order',
-    name: 'Fate Grand/Order',
-    url: 'https://www.fate-go.jp/',
-  },
-  {
-    id: 'idolmaster_cinderella_girls',
-    name: 'アイドルマスターシンデレラガールズ',
-    url: 'https://cinderella.idolmaster.jp/',
-  },
-  {
-    id: 'umamusume_pretty_derby',
-    name: 'ウマ娘 プリティーダービー',
-    url: 'https://umamusume.jp/',
-  },
-]
+type ResolverContext = {
+  readonly staticDataSources: StaticDataSources,
+}
 
-export const resolvers: Resolvers = {
+export const resolverContext: ResolverContext = {
+  staticDataSources,
+}
+
+export const resolvers: Resolvers<ResolverContext> = {
   Query: {
-    findGames: () => games,
+    findGames: (_parent, _args, context) => {
+      return context.staticDataSources.games.slice()
+    },
   },
 }


### PR DESCRIPTION
## 目的

.ts ファイルへ直接定義する静的なJSONデータ群をリゾルバの引数として渡したい。
リゾルバのテストの際に、モックできるようにするため。

## 渡し方の検討

- TS で直接定義してしまうデータの ApolloServer への渡し方がわからない。
  - https://www.apollographql.com/docs/apollo-server/api/apollo-server#options だと、 `dataSources` か `context` のどちらかのよう。
  - `dataSources` の方がそれっぽいけど、公式・準公式には方法が用意されてなさそう。
    - https://www.apollographql.com/docs/apollo-server/data/data-sources/#open-source-implementations
  - これ読んでみる) https://qiita.com/yutaro-t/items/b008779a8730c0e010c6
    - 自分で DataSource のサブクラスを作りたくない。
      - とりあえず context へ入れておく。