### PR TITLE
Change build/push process to use docker/build-push-action

### DIFF
--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -20,4 +20,6 @@ jobs:
         with:
           push: true
           tags: kjirou/sgrb:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - run: docker image ls

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: make docker/ci/build
+      -
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: kjirou/sgrb:latest
       - run: docker image ls
-      - run: docker tag sgr_ci:latest kjirou/sgr_ci
-      - run: docker push kjirou/sgr_ci:latest

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -2,7 +2,7 @@ name: Do Various Things After Pushing To Main
 on:
   push:
     branches:
-      - 'main'
+      - 'use_docker_build_and_push'
 jobs:
   save-ci-image:
     runs-on: ubuntu-20.04

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -2,7 +2,7 @@ name: Do Various Things After Pushing To Main
 on:
   push:
     branches:
-      - 'use_docker_build_and_push'
+      - 'main'
 jobs:
   save-ci-image:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## 疑問
- [x] `docker/build-push-action` で保存した docker image は、マルチステージビルドのどこまでが保存されているの？
  - 👉 `docker/build-push-action` で保存した image を手元に落として、`target=local` と `target=ci` が必要な `docker run` に使ってみたら両方で動いたので、全てが含まれていそう。
  - ドキュメント上どこに書いてあるのか、target は指定できるのかは不明。

## 参考資料
- https://zenn.dev/masibw/articles/57a47a7381b9b3
- https://zenn.dev/tatsurom/articles/githubactions-docker-cache
- https://cockscomb.hatenablog.com/entry/2022/02/16/092538