### PR TITLE
Don't push image to Docker Hub

### DIFF
--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -10,11 +10,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       -
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
         uses: docker/build-push-action@v3
         with:
           tags: sgrb:latest

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -7,7 +7,6 @@ jobs:
   save-ci-image:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       -

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -18,7 +18,6 @@ jobs:
       -
         uses: docker/build-push-action@v3
         with:
-          push: true
           tags: kjirou/sgrb:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -17,5 +17,5 @@ jobs:
       -
         uses: docker/build-push-action@v3
         with:
-          tags: kjirou/sgrb:latest
+          tags: sgrb:latest
           cache-to: type=gha,mode=max

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -13,4 +13,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           tags: sgrb:latest
+          # type=gha の設定のときは、GitHub Actions の Cache へ image を保存する。
+          # Cache はリポジトリに対して 10GB まで保存できる。超えた分は退去されるとのことで、具体的な処理は不明。
+          # ファイルが壊れて cache の restore が失敗することは、もしかしたらあるかもしれない。
+          #
+          # GitHub Actions: Cache の公式ドキュメント)
+          # https://docs.github.com/ja/actions/using-workflows/caching-dependencies-to-speed-up-workflows
           cache-to: type=gha,mode=max

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -2,7 +2,7 @@ name: Do Various Things After Pushing To Main
 on:
   push:
     branches:
-      - 'main'
+      - 'no_push_image'
 jobs:
   save-ci-image:
     runs-on: ubuntu-20.04

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -2,7 +2,7 @@ name: Do Various Things After Pushing To Main
 on:
   push:
     branches:
-      - 'no_push_image'
+      - 'main'
 jobs:
   save-ci-image:
     runs-on: ubuntu-20.04

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -19,6 +19,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           tags: kjirou/sgrb:latest
-          cache-from: type=gha
           cache-to: type=gha,mode=max
       - run: docker image ls

--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -20,4 +20,3 @@ jobs:
         with:
           tags: kjirou/sgrb:latest
           cache-to: type=gha,mode=max
-      - run: docker image ls


### PR DESCRIPTION
- [`docker/build-push-action`](https://github.com/docker/build-push-action) は GitHub Actions の Cache へデータを保存していたので、Docker Hub との連携は不要だった。

## 動作確認

これを入れて）
```diff
diff --git a/.github/workflows/do-various-things-after-pushing-to-main.yml b/.github/workflows/do-various-things-after-pushing-to-main.yml
index 2341817..1d26b6c 100644
--- a/.github/workflows/do-various-things-after-pushing-to-main.yml
+++ b/.github/workflows/do-various-things-after-pushing-to-main.yml
@@ -18,6 +18,4 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           tags: sgr_ci:latest
-          load: true
           cache-to: type=gha,mode=max
-      - run: docker image ls
```

確認よし）
<img width="869" alt="image" src="https://user-images.githubusercontent.com/648041/180227025-310645f6-7774-4a15-9239-86c35183decf.png">
