### PR TITLE
Share Docker images between jobs or workflows

### DIFF
--- a/.github/workflows/run-tests-and-analyze-code.yml
+++ b/.github/workflows/run-tests-and-analyze-code.yml
@@ -1,0 +1,59 @@
+name: Run Tests And Analyze Code
+on: [push]
+jobs:
+  save-docker-image-as-artifact:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        uses: docker/build-push-action@v3
+        with:
+          load: true
+          tags: sgrb:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - run: docker image ls
+      - run: docker save sgrb > /tmp/docker-image-sgrb.tar
+      -
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-image-sgrb
+          path: /tmp/docker-image-sgrb.tar
+  run-tests:
+    needs: save-docker-image-as-artifact
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      -
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-image-sgrb
+          path: /tmp
+      - run: ls -lAF /tmp
+      - run: docker load < /tmp/docker-image-sgrb.tar
+      - run: docker image ls
+      - run: make docker/ci/test
+  analyze-code:
+    needs: save-docker-image-as-artifact
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      -
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-image-sgrb
+          path: /tmp
+      - run: ls -lAF /tmp
+      - run: docker load < /tmp/docker-image-sgrb.tar
+      - run: docker image ls
+      - run: make docker/ci/analyze-code


### PR DESCRIPTION
## 止めた理由

- 既存の Workflow が 1m0s, 1m21s に対して 1m53s と遅くなっている。
  - `docker save` と `docker load`、そして Artifacts の処理が思ったより重く、直接 `cache-from: type=gha` するのと変わらない。
  - job が直列で 2 つ並ぶことになり、外部 actions 一式を呼び出す時間がそこそこ掛かる。
- Artifacts という外部処理を使う配慮が必要になる。（[公式ドキュメント](https://docs.github.com/ja/actions/using-workflows/storing-workflow-data-as-artifacts)）
  - 容量の制限は不明。見つからなかった。
  - 料金は Public Repository では無料という風に読めている。
- 構成が複雑になる。
- スケールしにくくなっている。

## 参考資料

`type=gha` を使えなくなる方法しなかくて、あまり関係がなかった。

- https://github.com/docker/build-push-action/issues/225
- [Docker : Re-use container image by caching](https://stackoverflow.com/questions/71348621/docker-re-use-container-image-by-caching)